### PR TITLE
revert qualifiable call identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@formulavize/lezer-fiz",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@formulavize/lezer-fiz",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@lezer/highlight": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formulavize/lezer-fiz",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "fiz grammar for lezer",
   "main": "dist/index.cjs",
   "type": "module",

--- a/src/fiz.grammar
+++ b/src/fiz.grammar
@@ -4,7 +4,7 @@ statement[@isGroup=Statement] { ( Call | RhsVariable | Alias | Assignment | Styl
 
 QualifiableIdentifier { Identifier ("." Identifier)* }
 
-Call { QualifiableIdentifier ArgList StyleArgList? }
+Call { Identifier ArgList StyleArgList? }
 
 ArgList { "(" ( value ("," value)* )? ")" }
 

--- a/test/assignments.txt
+++ b/test/assignments.txt
@@ -22,7 +22,7 @@ Recipe(
   Assignment(
     LhsVariable(Identifier),
     Eq,
-    Call(QualifiableIdentifier(Identifier), ArgList)
+    Call(Identifier, ArgList)
   )
 )
 
@@ -38,6 +38,6 @@ Recipe(
     LhsVariable(Identifier),
     LhsVariable(Identifier),
     Eq,
-    Call(QualifiableIdentifier(Identifier), ArgList)
+    Call(Identifier, ArgList)
   )
 )

--- a/test/calls.txt
+++ b/test/calls.txt
@@ -5,7 +5,7 @@ func()
 ==>
 
 Recipe(
-  Call(QualifiableIdentifier(Identifier), ArgList)
+  Call(Identifier, ArgList)
 )
 
 # One Variable
@@ -15,7 +15,7 @@ f( x )
 ==>
 
 Recipe(
-  Call(QualifiableIdentifier(Identifier), ArgList(
+  Call(Identifier, ArgList(
     RhsVariable(QualifiableIdentifier(Identifier))
   ))
 )
@@ -27,7 +27,7 @@ f(x,y)
 ==>
 
 Recipe(
-  Call(QualifiableIdentifier(Identifier), ArgList(
+  Call(Identifier, ArgList(
     RhsVariable(QualifiableIdentifier(Identifier)),
     RhsVariable(QualifiableIdentifier(Identifier))
   ))
@@ -41,7 +41,7 @@ f(x, y, z)
 
 Recipe(
   Call(
-    QualifiableIdentifier(Identifier),
+    Identifier,
     ArgList(
       RhsVariable(QualifiableIdentifier(Identifier)),
       RhsVariable(QualifiableIdentifier(Identifier)),
@@ -57,8 +57,8 @@ f(g())
 ==>
 
 Recipe(
-  Call(QualifiableIdentifier(Identifier), ArgList(
-    Call(QualifiableIdentifier(Identifier), ArgList)
+  Call(Identifier, ArgList(
+    Call(Identifier, ArgList)
   ))
 )
 
@@ -69,9 +69,9 @@ f( g( h() ) )
 ==>
 
 Recipe(
-  Call(QualifiableIdentifier(Identifier), ArgList(
-    Call(QualifiableIdentifier(Identifier), ArgList(
-      Call(QualifiableIdentifier(Identifier), ArgList)
+  Call(Identifier, ArgList(
+    Call(Identifier, ArgList(
+      Call(Identifier, ArgList)
     ))
   ))
 )
@@ -83,9 +83,9 @@ f ( x , g ( ) )
 ==>
 
 Recipe(
-  Call(QualifiableIdentifier(Identifier), ArgList(
+  Call(Identifier, ArgList(
     RhsVariable(QualifiableIdentifier(Identifier)),
-    Call(QualifiableIdentifier(Identifier), ArgList)
+    Call(Identifier, ArgList)
   ))
 )
 
@@ -99,8 +99,8 @@ f (
 ==>
 
 Recipe(
-  Call(QualifiableIdentifier(Identifier), ArgList(
-    Call(QualifiableIdentifier(Identifier), ArgList),
+  Call(Identifier, ArgList(
+    Call(Identifier, ArgList),
     RhsVariable(QualifiableIdentifier(Identifier))
   ))
 )
@@ -117,10 +117,10 @@ f(
 ==>
 
 Recipe(
-  Call(QualifiableIdentifier(Identifier), ArgList(
-    Call(QualifiableIdentifier(Identifier), ArgList(
+  Call(Identifier, ArgList(
+    Call(Identifier, ArgList(
       Call(
-        QualifiableIdentifier(Identifier),
+        Identifier,
         ArgList(
           RhsVariable(QualifiableIdentifier(Identifier)),
           RhsVariable(QualifiableIdentifier(Identifier))

--- a/test/namespaces.txt
+++ b/test/namespaces.txt
@@ -29,7 +29,7 @@ Recipe(
 Recipe(
   Namespace(
     StatementList(
-      Call(QualifiableIdentifier(Identifier), ArgList)
+      Call(Identifier, ArgList)
     )
   )
 )
@@ -69,7 +69,7 @@ Recipe(
         LhsVariable(Identifier),
         Eq,
         Call(
-          QualifiableIdentifier(Identifier),
+          Identifier,
           ArgList(RhsVariable(QualifiableIdentifier(Identifier)))
         )
       )

--- a/test/qualifiers.txt
+++ b/test/qualifiers.txt
@@ -1,21 +1,3 @@
-# Qualified Call Identifier
-
-n.x()
-n.m.x()
-
-==>
-
-Recipe(
-  Call(
-    QualifiableIdentifier(Identifier, Identifier),
-    ArgList
-  )
-  Call(
-    QualifiableIdentifier(Identifier, Identifier, Identifier),
-    ArgList
-  )
-)
-
 # Qualified RhsVariable in Alias
 
 a = b.c
@@ -41,7 +23,7 @@ Recipe(
     LhsVariable(Identifier),
     Eq,
     Call(
-      QualifiableIdentifier(Identifier),
+      Identifier,
       ArgList(RhsVariable(QualifiableIdentifier(Identifier, Identifier)))
     )
   )

--- a/test/statements.txt
+++ b/test/statements.txt
@@ -51,7 +51,7 @@ Recipe(
     LhsVariable(Identifier),
     Eq,
     Call(
-      QualifiableIdentifier(Identifier),
+      Identifier,
       ArgList(RhsVariable(QualifiableIdentifier(Identifier)))
     )
   )
@@ -60,7 +60,7 @@ Recipe(
     Eq,
     RhsVariable(QualifiableIdentifier(Identifier))
   ),
-  Call(QualifiableIdentifier(Identifier), ArgList)
+  Call(Identifier, ArgList)
 )
 
 # Line Comment
@@ -105,7 +105,7 @@ Recipe(
     LhsVariable(Identifier),
     Eq,
     Call(
-      QualifiableIdentifier(Identifier),
+      Identifier,
       ArgList(RhsVariable(QualifiableIdentifier(Identifier)))
     )
   )
@@ -116,7 +116,7 @@ Recipe(
     RhsVariable(QualifiableIdentifier(Identifier))
   ),
   BlockComment
-  Call(QualifiableIdentifier(Identifier), ArgList)
+  Call(Identifier, ArgList)
 )
 
 # Semicolons
@@ -132,7 +132,7 @@ Recipe(
     LhsVariable(Identifier),
     Eq,
     Call(
-      QualifiableIdentifier(Identifier),
+      Identifier,
       ArgList(RhsVariable(QualifiableIdentifier(Identifier)))
     )
   )
@@ -141,7 +141,7 @@ Recipe(
     Eq,
     RhsVariable(QualifiableIdentifier(Identifier))
   ),
-  Call(QualifiableIdentifier(Identifier), ArgList)
+  Call(Identifier, ArgList)
 )
 
 # Semicolons Same Line
@@ -154,9 +154,9 @@ Recipe(
   Assignment(
     LhsVariable(Identifier),
     Eq,
-    Call(QualifiableIdentifier(Identifier), ArgList)
+    Call(Identifier, ArgList)
   ),
-  Call(QualifiableIdentifier(Identifier), ArgList),
+  Call(Identifier, ArgList),
   Alias(
     LhsVariable(Identifier),
     Eq,
@@ -179,7 +179,7 @@ Recipe(
     LhsVariable(Identifier),
     Eq,
     Call(
-      QualifiableIdentifier(Identifier),
+      Identifier,
       ArgList(
       RhsVariable(QualifiableIdentifier(Identifier)),
       RhsVariable(QualifiableIdentifier(Identifier)),
@@ -210,7 +210,7 @@ Recipe(
     LhsVariable(Identifier),
     Eq,
     Call(
-      QualifiableIdentifier(Identifier),
+      Identifier,
       ArgList(RhsVariable(QualifiableIdentifier(Identifier)))
     )
   ),
@@ -218,7 +218,7 @@ Recipe(
     LhsVariable(Identifier),
     Eq,
     Call(
-      QualifiableIdentifier(Identifier),
+      Identifier,
       ArgList(RhsVariable(QualifiableIdentifier(Identifier)))
     )
   ),
@@ -227,7 +227,7 @@ Recipe(
     LhsVariable(Identifier),
     Eq,
     Call(
-      QualifiableIdentifier(Identifier),
+      Identifier,
       ArgList(RhsVariable(QualifiableIdentifier(Identifier)))
     )
   ),
@@ -235,7 +235,7 @@ Recipe(
     LhsVariable(Identifier),
     Eq,
     Call(
-      QualifiableIdentifier(Identifier),
+      Identifier,
       ArgList(RhsVariable(QualifiableIdentifier(Identifier)))
     )
   ),
@@ -243,7 +243,7 @@ Recipe(
   LineComment,
   LineComment,
   Call(
-    QualifiableIdentifier(Identifier),
+    Identifier,
     ArgList(RhsVariable(QualifiableIdentifier(Identifier)),
     RhsVariable(QualifiableIdentifier(Identifier)))
   )

--- a/test/styling.txt
+++ b/test/styling.txt
@@ -5,7 +5,7 @@ f(){}
 ==>
 
 Recipe(
-  Call(QualifiableIdentifier(Identifier), ArgList, StyleArgList)
+  Call(Identifier, ArgList, StyleArgList)
 )
 
 # Empty Variable StyleArgList
@@ -18,7 +18,7 @@ Recipe(
   Assignment(
     LhsVariable(Identifier, StyleArgList),
     Eq,
-    Call(QualifiableIdentifier(Identifier), ArgList)
+    Call(Identifier, ArgList)
   )
 )
 
@@ -35,19 +35,19 @@ Recipe(
     LhsVariable(Identifier, StyleArgList),
     LhsVariable(Identifier, StyleArgList),
     Eq,
-    Call(QualifiableIdentifier(Identifier), ArgList)
+    Call(Identifier, ArgList)
   )
   Assignment(
     LhsVariable(Identifier, StyleArgList),
     LhsVariable(Identifier),
     Eq,
-    Call(QualifiableIdentifier(Identifier), ArgList)
+    Call(Identifier, ArgList)
   )
   Assignment(
     LhsVariable(Identifier),
     LhsVariable(Identifier, StyleArgList),
     Eq,
-    Call(QualifiableIdentifier(Identifier), ArgList)
+    Call(Identifier, ArgList)
   )
 )
 
@@ -59,7 +59,7 @@ f(){num: "abc"}
 
 Recipe(
   Call(
-    QualifiableIdentifier(Identifier),
+    Identifier,
     ArgList,
     StyleArgList(StyleDeclaration(PropertyName, StringLiteral))
   )
@@ -76,7 +76,7 @@ f(){
 
 Recipe(
   Call(
-    QualifiableIdentifier(Identifier),
+    Identifier,
     ArgList,
     StyleArgList(
       StyleDeclaration(PropertyName, ColorLiteral),
@@ -100,7 +100,7 @@ f(){
 
 Recipe(
   Call(
-    QualifiableIdentifier(Identifier),
+    Identifier,
     ArgList,
     StyleArgList(
       StyleDeclaration(PropertyName, NumberLiteral),
@@ -124,7 +124,7 @@ f(){
 
 Recipe(
   Call(
-    QualifiableIdentifier(Identifier),
+    Identifier,
     ArgList,
     StyleArgList(
       StyleTag(QualifiableIdentifier(Identifier)),


### PR DESCRIPTION
Revert the ability for calls to have qualifiable identifiers. 
This may be added in the future, but for the initial release, I want to hold off on the idea of 'lazy' declaration of namespaces and enforce that language users explicitly declare namespaces through the `[ ... ]` syntax.