### PR TITLE
feat: add import statements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@formulavize/lezer-fiz",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@formulavize/lezer-fiz",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@lezer/highlight": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formulavize/lezer-fiz",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "fiz grammar for lezer",
   "main": "dist/index.cjs",
   "type": "module",

--- a/src/fiz.grammar
+++ b/src/fiz.grammar
@@ -1,6 +1,18 @@
 @top Recipe { statement* }
 
-statement[@isGroup=Statement] { ( Call | RhsVariable | Alias | Assignment | StyleTagDeclaration | StyleBinding | Namespace ) semi }
+statement[@isGroup=Statement] {
+  ( 
+    Call |
+    RhsVariable |
+    Alias |
+    Assignment |
+    StyleTagDeclaration |
+    StyleBinding |
+    Namespace |
+    Import
+  )
+  semi
+}
 
 QualifiableIdentifier { Identifier ("." Identifier)* }
 
@@ -51,6 +63,10 @@ StatementList { "[" statement* "]" }
 
 Namespace { Identifier? StatementList ArgList? StyleArgList? }
 
+Import { Identifier? "@" StringLiteral }
+// Import's StringLiteral should be some path-like resource identifier
+// Unquoted identifiers may be allowed if/when we make a package repository
+
 @skip { spaces | newline | LineComment | BlockComment }
 
 @context trackNewline from "./tokens.js"
@@ -96,6 +112,8 @@ Namespace { Identifier? StatementList ArgList? StyleArgList? }
   ":"
 
   "%"
+
+  "@"
 
   "(" ")" "{" "}" "[" "]"
 

--- a/test/namespaces.txt
+++ b/test/namespaces.txt
@@ -219,3 +219,21 @@ Recipe(
     StyleArgList
   )
 )
+
+# Import in Namespace
+
+[
+  @ "test"
+]
+
+==>
+
+Recipe(
+  Namespace(
+    StatementList(
+      Import(
+        StringLiteral
+      )
+    )
+  )
+)

--- a/test/statements.txt
+++ b/test/statements.txt
@@ -250,3 +250,35 @@ Recipe(
     )
   )
 )
+
+# Empty Anonymous Import
+
+@ ""
+
+==>
+
+Recipe(
+  Import(StringLiteral)
+)
+
+# Aliased Import
+
+test @ "testing"
+
+==>
+
+Recipe(
+  Import(Identifier, StringLiteral)
+)
+
+# Two Import Statements
+
+test @ "one"
+@ "two"
+
+==>
+
+Recipe(
+  Import(Identifier, StringLiteral)
+  Import(StringLiteral)
+)


### PR DESCRIPTION
add import statements to allow importing packages from a URL in StringLiteral into a statement's containing scope or a named namespace